### PR TITLE
Minimally update README for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ openssl-devel. For testing, you also need the `sq` command (version
 
 ## Building
 
-To build the shared library and bindings, do:
+To build the shared library and bindings on Linux, do:
 
 ```console
 $ PREFIX=/usr LIBDIR="\${prefix}/lib64" cargo build --release
+```
+
+On macOS, prefix the command with one more value:
+```console
+$ DYLD_FALLBACK_LIBRARY_PATH="$(xcode-select --print-path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/" PREFIX=…
 ```
 
 ## Installing
@@ -21,7 +26,7 @@ $ PREFIX=/usr LIBDIR="\${prefix}/lib64" cargo build --release
 Just copy the shared library in the library search path:
 
 ```console
-$ sudo cp -a rust/target/release/libpodman_sequoia.so* /usr/lib64
+$ sudo cp -a rust/target/release/libpodman_sequoia.* /usr/lib64
 ```
 
 ## Testing


### PR DESCRIPTION
Just document how to compile it (the extra path is required to find `libclang.dylib` without having to build `clang` from source; this does not yet deal with the right installation destination (there is no `/usr/lib64`).

Ultimately, I suppose a Homebrew formula would be easiest for everyone to use, but that’s not an immediate priority.