### PR TITLE
Improve signing code paths

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -552,7 +552,7 @@ mod tests {
                     sequoia_sign(
                         m1,
                         c_fingerprint.as_ptr(),
-                        std::ptr::null(),
+                        ptr::null(),
                         input.as_ptr(),
                         input.len(),
                         &mut err_ptr,
@@ -562,7 +562,7 @@ mod tests {
                 assert!(err_ptr.is_null());
                 let mut sig_size: size_t = 0;
                 let c_sig_data = unsafe { sequoia_signature_get_data(sig, &mut sig_size) };
-                let sig_slice = unsafe { std::slice::from_raw_parts(c_sig_data, sig_size) };
+                let sig_slice = unsafe { slice::from_raw_parts(c_sig_data, sig_size) };
                 signed = sig_slice.to_vec();
                 unsafe { sequoia_signature_free(sig) };
             }
@@ -610,8 +610,7 @@ mod tests {
                 let mut contents_size: size_t = 0;
                 let c_contents =
                     unsafe { sequoia_verification_result_get_content(res, &mut contents_size) };
-                let contents_slice =
-                    unsafe { std::slice::from_raw_parts(c_contents, contents_size) };
+                let contents_slice = unsafe { slice::from_raw_parts(c_contents, contents_size) };
                 assert_eq!(contents_slice, input);
 
                 let c_signer = unsafe { sequoia_verification_result_get_signer(res) };

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -116,7 +116,10 @@ impl<'a> SequoiaMechanism<'a> {
             .with_context(|| format!("Parsing certificate for {key_handle}"))?;
 
         let mut signing_key_handles: Vec<KeyHandle> = vec![];
-        for ka in cert.keys().with_policy(&self.policy, None).for_signing() {
+        let ka = cert
+            .with_policy(&self.policy, None)
+            .with_context(|| format!("No acceptable signing key for {key_handle}"))?;
+        for ka in ka.keys().for_signing() {
             signing_key_handles.push(ka.key().fingerprint().into());
         }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -89,7 +89,7 @@ impl<'a> SequoiaMechanism<'a> {
         let primary_key_handle: KeyHandle = key_handle.parse()?; // FIXME: For gpgme, allow lookup by user ID? grep_userid, or what is the compatible semantics?
         let certs = self
             .certstore
-            .lookup_by_cert_or_subkey(&primary_key_handle)
+            .lookup_by_cert(&primary_key_handle)
             .with_context(|| format!("Failed to load {key_handle} from certificate store"))?
             .into_iter()
             .filter_map(|cert| match cert.to_cert() {


### PR DESCRIPTION
- Make the semantics of the input parameter more strict, and reject ambiguities
- Then avoid unnecessary loops / vectors
- Don't ignore errors parsing data
- Match `sq` in looking for usable keys

This works against the basic tests in c/image, but I suppose this should have good test coverage — marking as draft for now, filing for early discussion / review.