### PR TITLE
Add tests for key imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,6 +2233,7 @@ dependencies = [
  "sequoia-keystore",
  "sequoia-openpgp",
  "sequoia-policy-config",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ crypto-cng = ["sequoia-openpgp/crypto-cng"]
 crypto-openssl = ["sequoia-openpgp/crypto-openssl"]
 crypto-botan = ["sequoia-openpgp/crypto-botan"]
 crypto-botan2 = ["sequoia-openpgp/crypto-botan2"]
+
+[dev-dependencies]
+tempfile = "3.20.0"

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -419,13 +419,6 @@ pub unsafe extern "C" fn sequoia_import_keys(
     assert!(!mechanism_ptr.is_null());
 
     let blob = slice::from_raw_parts(blob_ptr, blob_len);
-    if blob.is_empty() {
-        let result = SequoiaImportResult {
-            ..Default::default()
-        };
-        return Box::into_raw(Box::new(result));
-    }
-
     match (*mechanism_ptr).import_keys(blob) {
         Ok(result) => Box::into_raw(Box::new(result)),
         Err(e) => {
@@ -610,6 +603,12 @@ mod tests {
     #[test]
     fn import_keys() {
         // The basic case of import of a single key is tested in primary_workflow().
+
+        // Empty input.
+        let mut mech = SequoiaMechanism::ephemeral().unwrap();
+        let res = mech.import_keys(&[]);
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().key_handles, []);
 
         // A valid import of multiple keys.
         let pk1 = include_bytes!("./data/no-passphrase.pub");

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -65,13 +65,11 @@ impl<'a> SequoiaMechanism<'a> {
     fn import_keys(&mut self, blob: &[u8]) -> Result<SequoiaImportResult, anyhow::Error> {
         let mut key_handles = vec![];
         for r in CertParser::from_bytes(blob)? {
-            let cert = match r {
-                Ok(cert) => cert,
-                Err(err) => {
-                    log::info!("Error reading cert: {err}");
-                    continue;
-                }
-            };
+            // NOTE that we might have successfully imported something by now;
+            // in that case we just return an error and don't report what we have imported.
+            // That's fine for containers/image, which creates an one-use ephemeral mechanism
+            // and imports keys into it, i.e. there is no benefit in handling partial success specially.
+            let cert = r.context("Error parsing certificate")?;
 
             key_handles.push(CString::new(cert.fingerprint().to_hex().as_bytes()).unwrap());
             self.certstore
@@ -507,6 +505,8 @@ mod tests {
     use super::*;
 
     const TEST_KEY_FINGERPRINT: &str = "50DDE898DF4E48755C8C2B7AF6F908B6FA48A229";
+    const TEST_KEY_FINGERPRINT_WITH_PASSPHRASE: &str = "1F5825285B785E1DB13BF36D2D11A19ABA41C6AE";
+    const INVALID_PUBLIC_KEY_BLOB: &[u8] = b"\xC6\x09this is not a valid public key";
 
     #[test]
     fn primary_workflow() {
@@ -605,6 +605,54 @@ mod tests {
                 unsafe { sequoia_verification_result_free(res) };
             }
         });
+    }
+
+    #[test]
+    fn import_keys() {
+        // The basic case of import of a single key is tested in primary_workflow().
+
+        // A valid import of multiple keys.
+        let pk1 = include_bytes!("./data/no-passphrase.pub");
+        let pk2 = include_bytes!("./data/with-passphrase.pub");
+        let mut mech = SequoiaMechanism::ephemeral().unwrap();
+        let res = mech.import_keys(&[pk1.as_slice(), pk2.as_slice()].concat());
+        assert!(res.is_ok());
+        assert_eq!(
+            res.unwrap().key_handles,
+            [
+                CString::new(TEST_KEY_FINGERPRINT).unwrap(),
+                CString::new(TEST_KEY_FINGERPRINT_WITH_PASSPHRASE).unwrap(),
+            ],
+        );
+
+        let mut mech = SequoiaMechanism::ephemeral().unwrap();
+        let res = mech.import_keys(b"this is not a valid public key");
+        // "unexpected EOF": When the input does not look like binary OpenPGP, the code tries to parse it as ASCII-armored,
+        // and looks for a BEGIN… header.
+        assert!(res.is_err());
+
+        let mut mech = SequoiaMechanism::ephemeral().unwrap();
+        let res = mech.import_keys(INVALID_PUBLIC_KEY_BLOB);
+        // "Error parsing certificate" Malformed packet: Truncated packet": The input starts with a valid enough OpenPGP packet header.
+        assert!(res.is_err());
+
+        // Generally, the certstore.update call should never fail for ephemeral mechanisms; it might fail
+        // - if the provided LazyCert can’t be parsed, but we already have a parsed form
+        // - on an internal inconsistency of CertStore, if it tries to merge two certificates with different fingerprints
+        // but, purely for test purposes, we can trigger a write failure by using a non-ephemeral mechanism
+        // (which is not expected to happen in practice).
+        if cfg!(unix) {
+            let sequoia_home = tempfile::tempdir().unwrap();
+            let certstore_dir = sequoia_directories::Home::new(sequoia_home.path().to_path_buf())
+                .unwrap()
+                .data_dir(sequoia_directories::Component::CertD);
+            let mut mech = SequoiaMechanism::from_directory(Some(sequoia_home.path())).unwrap();
+            // Forcefully delete the contents of certstore_dir, and replace it with a dangling symlink.
+            fs::remove_dir_all(&certstore_dir).unwrap();
+            std::os::unix::fs::symlink("/var/empty/this/does/not/exist", &certstore_dir).unwrap();
+            let res = mech.import_keys(pk1);
+            assert!(res.is_err());
+        }
     }
 
     // with_c_ephemeral_mechanism runs the provided function with a C-interface ephemeral mechanism,


### PR DESCRIPTION
<s>This is on top of unmerged #8, otherwise ready for review/merging.</s>

Some implementation cleanups to the import functionality, and full test code coverage. (I don’t feel very strongly about the error handling change, I’d be fine with reverting that part.)