### PR TITLE
Update dlwrap generated files with new license notice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -913,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "dlwrap"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76810e38c6f0f7195a0cac883d832ad514036777490d81d48665d66314debee5"
+checksum = "98b05d42090b0a96231ada2e4bde44edc3c98e1b78c2604570e0e9656fde54d2"
 dependencies = [
  "anyhow",
  "clang",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-dirs = "5"
+dirs = "6"
 libc = "0.2"
 log = "0.4"
 sequoia-cert-store = { version = "0.7", default-features = false }
@@ -28,7 +28,7 @@ sequoia-policy-config = "0.8"
 anyhow = "1"
 cbindgen = "0.24.0"
 cdylib-link-lines = "0.1.4"
-dlwrap = "0.3.7"
+dlwrap = "0.3.8"
 regex = "1"
 
 [features]

--- a/go/sequoia/gosequoia.c
+++ b/go/sequoia/gosequoia.c
@@ -1,8 +1,12 @@
 /*
- * Copying and distribution of this file, with or without modification,
- * are permitted in any medium without royalty provided the copyright
- * notice and this notice are preserved.  This file is offered as-is,
- * without any warranty.
+ * SPDX-License-Identifier: Apache-2.0 OR FSFAP
+ * SPDX-FileCopyrightText: 2025 Daiki Ueno
+ *
+ * You can redistribute and/or modify this file under the terms of either
+ * Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html), or
+ * FSF All Permissive License
+ * (https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html),
+ * or both in parallel, as here.
  */
 
 #ifdef HAVE_CONFIG_H

--- a/go/sequoia/gosequoia.h
+++ b/go/sequoia/gosequoia.h
@@ -1,8 +1,12 @@
 /*
- * Copying and distribution of this file, with or without modification,
- * are permitted in any medium without royalty provided the copyright
- * notice and this notice are preserved.  This file is offered as-is,
- * without any warranty.
+ * SPDX-License-Identifier: Apache-2.0 OR FSFAP
+ * SPDX-FileCopyrightText: 2025 Daiki Ueno
+ *
+ * You can redistribute and/or modify this file under the terms of either
+ * Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0.html), or
+ * FSF All Permissive License
+ * (https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html),
+ * or both in parallel, as here.
  */
 
 #ifndef GO_SEQUOIA_H_


### PR DESCRIPTION
This propagate the license change of the generated C files from FSFAP
to "Apache-2.0 OR FSFAP". See
https://github.com/containers/container-libs/pull/473 for details.