### PR TITLE
Tighten CI for future proof

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,6 @@ jobs:
     - name: Check ABI compatibility
       run: abidb --loglevel debug --sysroot target/debug --check target/debug/libpodman_sequoia.so.0
     - name: Run Rust tests
-      run: cargo test --verbose
+      run: SEQUOIA_CRYPTO_POLICY=/dev/null cargo test --verbose
     - name: Run Go tests
       run: make -C go check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,8 @@ jobs:
         git branch fedora/42/x86_64 origin/fedora/42/x86_64
     - name: Build
       run: cargo build --verbose
+    - name: Check that the working directory is clean
+      run: test -z $(git status --porcelain --untracked-files=no) || exit 1
     - name: Check ABI compatibility
       run: abidb --loglevel debug --sysroot target/debug --check target/debug/libpodman_sequoia.so.0
     - name: Run Rust tests


### PR DESCRIPTION
This ensures the following:

- Cargo.lock is properly updated when Cargo.toml has changed
- Use the built-in crypto-policies instead of the system-wide settings as it may not know new keywords