### PR TITLE
ci: Manually call abidiff instead of abidb --check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,9 @@ jobs:
     - name: Check that the working directory is clean
       run: test -z $(git status --porcelain --untracked-files=no) || exit 1
     - name: Check ABI compatibility
-      run: abidb --loglevel debug --sysroot target/debug --check target/debug/libpodman_sequoia.so.0
+      run: |
+        git worktree add abi fedora/42/x86_64
+        abidiff --verbose target/debug/libpodman_sequoia.so.0 abi/libpodman_sequoia.so.0/*.xml
     - name: Run Rust tests
       run: cargo test --verbose
     - name: Run Go tests


### PR DESCRIPTION
abidb --check uses abicompat, which can only check the API used by the given applications. Switch to using abidiff to actually check the ABI difference between two shared libs.